### PR TITLE
Adapt mlog to use in the Qt Creator wizard.

### DIFF
--- a/mlog.cpp
+++ b/mlog.cpp
@@ -79,8 +79,10 @@ bool MLog::_logToConsole = true;
  */
 MLog::MLog()
 {
-    qSetMessagePattern("%{time}|%{type}%{if-category}|%{category}%{endif}|%{function}: "
-                       "%{message}");
+    // use backslashes between '%' and '{' to avoid shadowing this placeholders with
+    // similar placeholders from wizard.json file during the Qt Creator wizard creation
+    qSetMessagePattern("%\{time}|%\{type}%\{if-category}|%\{category}%\{endif}|%\{function}: "
+                       "%\{message}");
     qInstallMessageHandler(&messageHandler);
 }
 

--- a/tst_mlog/tst_mlog.cpp
+++ b/tst_mlog/tst_mlog.cpp
@@ -120,7 +120,7 @@ void TestMLog::testLogToConsole()
 
     QVERIFY(fileSize1 == fileSize2);
 
-
+    clean();
 }
 
 void TestMLog::testInThread()


### PR DESCRIPTION
First change in mlog.cpp file is made for adapting mlog to use in the Qt Creator wizard.
Second change  in tst_mlog/tst_mlog.cpp probably fix bug for tests (before this change, if first run was success then next tries are failing).